### PR TITLE
Fix AbstractMethodError in TextConfigInput

### DIFF
--- a/src/main/java/de/siphalor/coat/input/TextConfigInput.java
+++ b/src/main/java/de/siphalor/coat/input/TextConfigInput.java
@@ -64,6 +64,14 @@ public class TextConfigInput extends TextFieldWidget implements ConfigInput<Stri
 	 * {@inheritDoc}
 	 */
 	@Override
+	public void tick() {
+		super.tick();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public void render(MatrixStack matrices, int x, int y, int width, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
 		this.x = x + 2;
 		this.y = y + 2;


### PR DESCRIPTION
## Issue

mouse-wheelie 1.7.3-newconfig crashes with an `AbstractMethodError` when trying to open the "General" config category.

## Description

`TextConfigInput` implements the interface `ConfigInput`, which has a `tick()` method.
`TextConfigInput` itself doesn't implement this method but it extends from (vanilla) `TextFieldWidget` which does have it.

This compiles fine and the IDE doesn't complain either, but since `TextFieldWidget` is obfuscated, `TextFieldWidget`'s `tick()` will, at runtime (outside the devenv), have a different name and therefore `TextConfigInput` won't actually implement the interface anymore, causing an `AbstractMethodError`.

## Fix

One fix is to add an (unobfuscated) `tick()` method to `TextConfigInput`, calling the (obfuscated) `super.tick()` method, which is what I did here (and it seems you did that too for `setFocused()`).

I think this can also be fixed by writing a Mixin for `TextFieldWidget` which `@Shadow`s all needed methods and letting `TextConfigInput` extends from that mixin instead. That way `TextConfigInput` doesn't actually have to have the methods but the interface methods should 'redirect' to the `TextFieldWidget` methods.
Haven't tried that though, maybe that only works if the mixin itself implements an interface.